### PR TITLE
Updating broken fix for #17 on modern socket.io

### DIFF
--- a/ep_ldapauth.js
+++ b/ep_ldapauth.js
@@ -172,6 +172,7 @@ exports.handleMessage = function(hook_name, context, cb) {
     if (!context.message.token) {
       console.debug('ep_ldapauth.handleMessage: intercepted CLIENT_READY message has no token!');
     } else {
+      var client_id = context.client.id;
       if ('user' in context.client.client.request.session) {
         var displayName = context.client.client.request.session.user.displayName;
         if(settings.users.ldapauth.anonymousReadonly && !displayName) displayName = 'guest';


### PR DESCRIPTION
Re-adding the (accidentally?) removed line defining client.id. 