### PR TITLE
Skip admin binding if searchDN is not defined

### DIFF
--- a/lib/MyLdapAuth.js
+++ b/lib/MyLdapAuth.js
@@ -39,7 +39,6 @@ var ldap = require('ldapjs');
 function MyLdapAuth(opts) {
   this.opts = opts;
   assert.ok(opts.url);
-  assert.ok(opts.adminDn);
   assert.ok(opts.searchBase);
   assert.ok(opts.searchFilter);
 
@@ -78,15 +77,20 @@ MyLdapAuth.prototype._adminBind = function (cb) {
     clientOpts.tlsOptions = {};
     clientOpts.tlsOptions.ca = self.opts.tls_ca;
   }
-  
+
   self._adminClient = ldap.createClient(clientOpts);
-  self._adminClient.bind(self.opts.adminDn, self.opts.adminPassword,
-    function (err) {
-    if (err) {
-      return cb(util.format('ldap bind with %s to %s failed: %s', self.opts.adminDn, self.opts.url, err));
-    }
+  if (typeof(self.opts.adminDn) !== 'undefined') {
+    self._adminClient.bind(self.opts.adminDn, self.opts.adminPassword,
+      function (err) {
+      if (err) {
+        return cb(util.format('ldap bind with %s to %s failed: %s', self.opts.adminDn, self.opts.url, err));
+      }
+      return cb();
+    });
+  }
+  else {
     return cb();
-  });
+  }
 }
 
 /**


### PR DESCRIPTION
For anonymous ldap access it's enough just to omit searchDN option in settings.json