### PR TITLE
Fix admin authorization on recent Etherpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Add to settings.json:
     },
 
 Users who are in the matches group have *admin* access to
-etherpad-lite.
+etherpad-lite. Note that once they gain access to an admin session once,
+they can use this session in the future to retain admin access even if
+they are removed from the admin group.
 
 ## Using with FreeIPA
 

--- a/ep.json
+++ b/ep.json
@@ -4,7 +4,6 @@
       "name": "ep_ldapauth",
       "hooks": {
         "authenticate": "ep_ldapauth/ep_ldapauth",
-        "authorize": "ep_ldapauth/ep_ldapauth",
         "handleMessage": "ep_ldapauth/ep_ldapauth"
       }
     }


### PR DESCRIPTION
As of Etherpad 1.8.7 (and possibly earlier), the authorize hook did not
seem to be called anymore. According to the documentation, it is not
called for admin paths, and recent Etherpads allow admin access only to
admin users anyway.
Thus, this commit moves the admin check to be part of authentication.
This has the disadvantage that admin sessions will stay valid even if a
user is removed from an admin group, which is now documented in the
README.

---

Tested on Etherpad 1.8.7.
I did not test the `anonymousReadonly` feature. It's possible that some of this may need to be moved to a preAuthorize hook, but I did not test it. Though the [documentation about the authorize hook](https://etherpad.org/doc/v1.8.7/#index_authorize) writes:
> (Requests for static content and API endpoints are always authorized, even if unauthenticated.)

The code certainly is not pretty, but is mostly inherited from the old code.