### PR TITLE
Document the tls_ca_file parameter in the readme and use it to also to ignore peer certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Add to settings.json:
             "groupAttributeIsDN": true,
             "searchScope": "sub",
             "groupSearch": "(&(cn=admin)(objectClass=groupOfNames))",
-            "anonymousReadonly": false
+            "anonymousReadonly": false,
+            // The following is optional. You can also set it to false to ignore peer certificates
+            "tls_ca_file": "/path/to/yourcert.pem"
         }
     },
 

--- a/ep_ldapauth.js
+++ b/ep_ldapauth.js
@@ -40,7 +40,13 @@ exports.authenticate = function(hook_name, context, cb) {
     };
 
     if (typeof(settings.users.ldapauth.tls_ca_file) !== 'undefined') {
-      myLdapAuthOpts.tls_ca = fs.readFileSync(settings.users.ldapauth.tls_ca_file);
+      // if parameter tls_ca_file is set to false, then ignore client certificates,
+      // else, use the provided PEM format certificate
+      if (settings.users.ldapauth.tls_ca_file == false) {
+        myLdapAuthOpts.tls_ca = false;
+      } else {
+        myLdapAuthOpts.tls_ca = fs.readFileSync(settings.users.ldapauth.tls_ca_file);
+      }
     }
 
     var authenticateLDAP = new MyLdapAuth(myLdapAuthOpts);

--- a/lib/MyLdapAuth.js
+++ b/lib/MyLdapAuth.js
@@ -75,7 +75,12 @@ MyLdapAuth.prototype._adminBind = function (cb) {
 
   if (typeof(self.opts.tls_ca !== 'undefined')) {
     clientOpts.tlsOptions = {};
-    clientOpts.tlsOptions.ca = self.opts.tls_ca;
+    // if tls_ca is set to false, then ignore certificates, else use the provided one
+    if (self.opts.tls_ca == false) {
+      clientOpts.tlsOptions.rejectUnauthorized = false;
+    } else {
+      clientOpts.tlsOptions.ca = self.opts.tls_ca;
+    }
   }
 
   self._adminClient = ldap.createClient(clientOpts);
@@ -158,7 +163,12 @@ MyLdapAuth.prototype.authenticate = function (username, password, cb) {
 
     if (typeof(self.opts.tls_ca !== 'undefined')) {
       clientOpts.tlsOptions = {};
-      clientOpts.tlsOptions.ca = self.opts.tls_ca;
+      // if tls_ca is set to false, then ignore certificates, else use the provided one
+      if (self.opts.tls_ca == false) {
+        clientOpts.tlsOptions.rejectUnauthorized = false;
+      } else {
+        clientOpts.tlsOptions.ca = self.opts.tls_ca;
+      }
     }
 
     var userClient = ldap.createClient(clientOpts);


### PR DESCRIPTION
With this change, it is possible to set the **tls_ca_file** parameter to false to ignore peer certificates